### PR TITLE
Disable rust-cache on virtualenv; debug files are too big

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,3 +155,50 @@ jobs:
       - name: Test Nushell in virtualenv
         run: cd virtualenv && tox -e ${{ matrix.py }} -- -k nushell
         shell: bash
+
+  plugins:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-latest]
+        rust:
+          - stable
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      # This job does not use rust-cache because 1) we have limited cache space, 2) even 
+      # without caching, it's not the slowest job. Revisit if those facts change.
+
+      - name: Build nu_plugin_example
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --package nu_plugin_example
+
+      - name: Build nu_plugin_gstat
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --package nu_plugin_gstat
+
+      - name: Build nu_plugin_inc
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --package nu_plugin_inc
+
+      - name: Build nu_plugin_query
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --package nu_plugin_query


### PR DESCRIPTION
… cache

# Description

(description of your pull request here)

# Tests

Make sure you've run and fixed any issues with these commands:

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --all --all-features -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo build; cargo test --all --all-features` to check that all the tests pass
