### PR TITLE
Remove ASSOC and FTYPE from allowed CMD builtins

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -165,8 +165,7 @@ impl ExternalCommand {
                     // This has the full list of cmd.exe "internal" commands: https://ss64.com/nt/syntax-internal.html
                     // I (Reilly) went through the full list and whittled it down to ones that are potentially useful:
                     const CMD_INTERNAL_COMMANDS: [&str; 10] = [
-                        "ASSOC", "CLS", "DIR", "ECHO", "FTYPE", "MKLINK", "PAUSE", "START", "VER",
-                        "VOL",
+                        "CLS", "DIR", "ECHO", "MKLINK", "PAUSE", "START", "VER", "VOL",
                     ];
                     let command_name_upper = self.name.item.to_uppercase();
                     let looks_like_cmd_internal = CMD_INTERNAL_COMMANDS


### PR DESCRIPTION
They no longer function as expected on Win8+: https://stackoverflow.com/a/51727990. As such, exposing them through nu doesn't make any sense.

I confirmed on my Win11 machine that `assoc`/`ftype` show a file type association from `.html` to IE, despite the actual association on my machine being to Firefox.

cc @rgwood 

- [ ] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [ ] `cargo clippy --workspace --features=extra -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [ ] `cargo test --workspace --features=extra` to check that all the tests pass
