### PR TITLE
WIP criterion benchmarks

### DIFF
--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -1,19 +1,39 @@
+use std::time::Instant;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use nu_parser::parse;
-use nu_protocol::{Value, Span};
-use nu_utils::{get_default_config, get_default_env};
+use nu_protocol::{Span, Value};
+use nu_utils::get_default_config;
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut engine_state = nu_command::create_default_context();
     // parsing breaks without PWD set
-    engine_state.add_env_var("PWD".into(),  Value::string(std::env::current_dir().unwrap().to_string_lossy().to_owned(), Span::test_data()));
-    let mut working_set = nu_protocol::engine::StateWorkingSet::new(&engine_state);
+    engine_state.add_env_var(
+        "PWD".into(),
+        Value::string(
+            std::env::current_dir()
+                .unwrap()
+                .to_string_lossy()
+                .to_owned(),
+            Span::test_data(),
+        ),
+    );
     let default_config = get_default_config().as_bytes();
 
-    c.bench_function("parse config", |b| b.iter(|| {
-        nu_parser::parse(&mut working_set, None, default_config, false, &[]);
-    }));
+    c.bench_function("parse config", |b| {
+        b.iter_custom(|iters| {
+            (0..iters)
+                .map(|_| {
+                    let mut working_set = nu_protocol::engine::StateWorkingSet::new(&engine_state);
+                    let start = Instant::now();
+
+                    black_box(nu_parser::parse(&mut working_set, None, default_config, false, &[]));
+                    start.elapsed()
+                })
+                .sum()
+        })
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);
+


### PR DESCRIPTION
Iteration would cause growing of the stored working set of defs etc.

After:
```

     Running benches/parser.rs (target/release/deps/parser-aac4614e0ba8b910)
Benchmarking parse config: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.3s, enable flat sampling, or reduce sample count to 50.
parse config            time:   [1.8112 ms 1.8139 ms 1.8163 ms]
                        change: [-0.6209% -0.3693% -0.1163%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
```
Before:
```
     Running benches/parser.rs (target/release/deps/parser-aac4614e0ba8b910)
parse config            time:   [116.71 ms 122.65 ms 128.65 ms]
                        change: [+6322.4% +6676.1% +7012.2%] (p = 0.00 < 0.05)
                        Performance has regressed.
```