### PR TITLE
Best-effort column completion in pipelines

### DIFF
--- a/crates/nu-cli/src/commands/history/history_.rs
+++ b/crates/nu-cli/src/commands/history/history_.rs
@@ -60,6 +60,39 @@ impl Command for History {
         ]
     }
 
+    fn infer_output_type(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &nu_protocol::ast::Call,
+        _input_type: &Type,
+    ) -> Option<Type> {
+        // Best-effort: assume the (default) sqlite history backend. Plaintext history
+        // produces fewer columns; users on plaintext history won't get column completion.
+        let long = call.has_flag_const(working_set, "long").unwrap_or(false);
+        let columns: Vec<(String, Type)> = if long {
+            vec![
+                ("item_id".into(), Type::Int),
+                ("start_timestamp".into(), Type::Date),
+                ("command".into(), Type::String),
+                ("session_id".into(), Type::Int),
+                ("hostname".into(), Type::String),
+                ("cwd".into(), Type::String),
+                ("duration".into(), Type::Duration),
+                ("exit_status".into(), Type::Int),
+                ("idx".into(), Type::Int),
+            ]
+        } else {
+            vec![
+                ("start_timestamp".into(), Type::Date),
+                ("command".into(), Type::String),
+                ("cwd".into(), Type::String),
+                ("duration".into(), Type::Duration),
+                ("exit_status".into(), Type::Int),
+            ]
+        };
+        Some(Type::Table(columns.into()))
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-cli/src/completions/arg_value_completion.rs
+++ b/crates/nu-cli/src/completions/arg_value_completion.rs
@@ -8,10 +8,19 @@ use crate::{
 };
 use nu_parser::parse_module_file_or_dir;
 use nu_protocol::{
-    DynamicCompletionCallRef, Span,
+    DynamicCompletionCallRef, Span, SyntaxShape, Type,
     ast::{Argument, Call, Expr, Expression, ListItem},
     engine::{ArgType, Stack, StateWorkingSet},
 };
+
+/// Check if a SyntaxShape contains CellPath (directly or inside OneOf)
+fn shape_contains_cell_path(shape: &SyntaxShape) -> bool {
+    match shape {
+        SyntaxShape::CellPath => true,
+        SyntaxShape::OneOf(shapes) => shapes.iter().any(|s| shape_contains_cell_path(s)),
+        _ => false,
+    }
+}
 
 pub struct ArgValueCompletion<'a> {
     pub call: &'a Call,
@@ -21,6 +30,7 @@ pub struct ArgValueCompletion<'a> {
     pub arg_idx: usize,
     pub pos: usize,
     pub strip: bool,
+    pub pipeline_input_type: Option<&'a Type>,
 }
 
 impl<'a> Completer for ArgValueCompletion<'a> {
@@ -76,6 +86,31 @@ impl<'a> Completer for ArgValueCompletion<'a> {
             }
             // fallback to type based completion, file completion, etc.
             Ok(None) => (),
+        }
+
+        // Try column name completion from pipeline input type
+        if let Some(input_type) = self.pipeline_input_type {
+            if let ArgType::Positional(positional_arg_index) = self.arg_type {
+                let signature = decl.signature();
+                if let Some(pos_arg) = signature.get_positional(positional_arg_index) {
+                    if shape_contains_cell_path(&pos_arg.shape) {
+                        let suggestions =
+                            super::cell_path_completions::get_suggestions_by_type(
+                                input_type,
+                                reedline::Span {
+                                    start: span.start - offset,
+                                    end: span.end - offset,
+                                },
+                            );
+                        if !suggestions.is_empty() {
+                            for suggestion in suggestions {
+                                matcher.add_semantic_suggestion(suggestion);
+                            }
+                            return matcher.suggestion_results();
+                        }
+                    }
+                }
+            }
         }
 
         let command_head = decl.name();

--- a/crates/nu-cli/src/completions/arg_value_completion.rs
+++ b/crates/nu-cli/src/completions/arg_value_completion.rs
@@ -17,7 +17,7 @@ use nu_protocol::{
 fn shape_contains_cell_path(shape: &SyntaxShape) -> bool {
     match shape {
         SyntaxShape::CellPath => true,
-        SyntaxShape::OneOf(shapes) => shapes.iter().any(|s| shape_contains_cell_path(s)),
+        SyntaxShape::OneOf(shapes) => shapes.iter().any(shape_contains_cell_path),
         _ => false,
     }
 }
@@ -89,26 +89,25 @@ impl<'a> Completer for ArgValueCompletion<'a> {
         }
 
         // Try column name completion from pipeline input type
-        if let Some(input_type) = self.pipeline_input_type {
-            if let ArgType::Positional(positional_arg_index) = self.arg_type {
-                let signature = decl.signature();
-                if let Some(pos_arg) = signature.get_positional(positional_arg_index) {
-                    if shape_contains_cell_path(&pos_arg.shape) {
-                        let suggestions =
-                            super::cell_path_completions::get_suggestions_by_type(
-                                input_type,
-                                reedline::Span {
-                                    start: span.start - offset,
-                                    end: span.end - offset,
-                                },
-                            );
-                        if !suggestions.is_empty() {
-                            for suggestion in suggestions {
-                                matcher.add_semantic_suggestion(suggestion);
-                            }
-                            return matcher.suggestion_results();
-                        }
+        if let Some(input_type) = self.pipeline_input_type
+            && let ArgType::Positional(positional_arg_index) = self.arg_type
+        {
+            let signature = decl.signature();
+            if let Some(pos_arg) = signature.get_positional(positional_arg_index)
+                && shape_contains_cell_path(&pos_arg.shape)
+            {
+                let suggestions = super::cell_path_completions::get_suggestions_by_type(
+                    input_type,
+                    reedline::Span {
+                        start: span.start - offset,
+                        end: span.end - offset,
+                    },
+                );
+                if !suggestions.is_empty() {
+                    for suggestion in suggestions {
+                        matcher.add_semantic_suggestion(suggestion);
                     }
+                    return matcher.suggestion_results();
                 }
             }
         }

--- a/crates/nu-cli/src/completions/cell_path_completions.rs
+++ b/crates/nu-cli/src/completions/cell_path_completions.rs
@@ -155,7 +155,10 @@ fn get_suggestions_by_value(
     }
 }
 
-fn get_suggestions_by_type(ty: &Type, current_span: reedline::Span) -> Vec<SemanticSuggestion> {
+pub(crate) fn get_suggestions_by_type(
+    ty: &Type,
+    current_span: reedline::Span,
+) -> Vec<SemanticSuggestion> {
     match ty {
         Type::Record(fields) | Type::Table(fields) => fields
             .iter()

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -5,7 +5,7 @@ use crate::completions::{
 };
 use nu_parser::parse;
 use nu_protocol::{
-    CommandWideCompleter, Completion, GetSpan, Signature, Span,
+    CommandWideCompleter, Completion, GetSpan, Signature, Span, Type,
     ast::{
         Argument, Block, Expr, Expression, FindMapResult, PipelineRedirection, RedirectionTarget,
         Traverse,
@@ -146,6 +146,82 @@ fn strip_placeholder_if_any<'a>(
     (new_span, prefix)
 }
 
+/// Compute the pipeline input type for the element at `pos` within a block.
+///
+/// Walks through all pipelines in the block, finds the pipeline containing `pos`,
+/// then propagates types through all elements preceding `pos` to determine what
+/// type of data flows into the element being completed.
+///
+/// Uses `Command::infer_output_type()` when available for flag-aware inference,
+/// falling back to the command signature's `input_output_types`.
+fn compute_pipeline_input_type(
+    block: &Block,
+    working_set: &StateWorkingSet,
+    pos: usize,
+) -> Option<Type> {
+    for pipeline in &block.pipelines {
+        // Find which element in this pipeline contains `pos`
+        let cursor_element_idx = pipeline
+            .elements
+            .iter()
+            .position(|elem| elem.expr.span.contains(pos));
+
+        let cursor_idx = match cursor_element_idx {
+            Some(idx) if idx == 0 => return None, // first element has no pipeline input
+            Some(idx) => idx,
+            None => continue,
+        };
+
+        // Propagate types through all preceding elements
+        let mut current_type = Type::Any;
+
+        for elem in &pipeline.elements[..cursor_idx] {
+            if elem.redirection.is_some() {
+                current_type = Type::Any;
+                continue;
+            }
+            if let Expr::Call(call) = &elem.expr.expr {
+                let decl = working_set.get_decl(call.decl_id);
+
+                // Try flag-aware inference first
+                if let Some(inferred) =
+                    decl.infer_output_type(working_set, call, &current_type)
+                {
+                    current_type = inferred;
+                    continue;
+                }
+
+                // Fall back to signature's input_output_types
+                let io_types = decl.signature().input_output_types;
+                if io_types.is_empty() {
+                    current_type = Type::Any;
+                } else {
+                    // Collect all possible output types given the current input type
+                    let output_types: Vec<Type> = io_types
+                        .into_iter()
+                        .filter(|(in_type, _)| {
+                            current_type == Type::Any || in_type == &Type::Any || in_type == &current_type
+                        })
+                        .map(|(_, out_type)| out_type)
+                        .collect();
+
+                    current_type = match output_types.len() {
+                        0 => Type::Any,
+                        1 => output_types.into_iter().next().unwrap(),
+                        _ => Type::Any, // multiple possibilities, can't narrow
+                    };
+                }
+            } else {
+                current_type = elem.expr.ty.clone();
+            }
+        }
+
+        return Some(current_type);
+    }
+
+    None
+}
+
 #[derive(Clone)]
 pub struct NuCompleter {
     engine_state: Arc<EngineState>,
@@ -249,6 +325,9 @@ impl NuCompleter {
         let Some(text) = contents.get(start_offset..pos) else {
             return vec![];
         };
+        let pipeline_input_type =
+            compute_pipeline_input_type(&block, working_set, pos_to_search);
+
         self.complete_by_expression(
             working_set,
             element_expression,
@@ -256,6 +335,7 @@ impl NuCompleter {
             pos_to_search,
             text,
             extra_placeholder,
+            pipeline_input_type.as_ref(),
         )
     }
 
@@ -275,6 +355,7 @@ impl NuCompleter {
         pos: usize,
         prefix_str: &str,
         strip: bool,
+        pipeline_input_type: Option<&Type>,
     ) -> Vec<SemanticSuggestion> {
         let mut suggestions: Vec<SemanticSuggestion> = vec![];
 
@@ -484,6 +565,7 @@ impl NuCompleter {
                                 arg_idx,
                                 pos,
                                 strip,
+                                pipeline_input_type,
                             };
                             suggestions.splice(
                                 0..0,
@@ -569,6 +651,7 @@ impl NuCompleter {
                                 arg_idx,
                                 pos,
                                 strip,
+                                pipeline_input_type,
                             };
 
                             suggestions.splice(

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -167,7 +167,7 @@ fn compute_pipeline_input_type(
             .position(|elem| elem.expr.span.contains(pos));
 
         let cursor_idx = match cursor_element_idx {
-            Some(idx) if idx == 0 => return None, // first element has no pipeline input
+            Some(0) => return None, // first element has no pipeline input
             Some(idx) => idx,
             None => continue,
         };
@@ -184,9 +184,7 @@ fn compute_pipeline_input_type(
                 let decl = working_set.get_decl(call.decl_id);
 
                 // Try flag-aware inference first
-                if let Some(inferred) =
-                    decl.infer_output_type(working_set, call, &current_type)
-                {
+                if let Some(inferred) = decl.infer_output_type(working_set, call, &current_type) {
                     current_type = inferred;
                     continue;
                 }
@@ -200,15 +198,17 @@ fn compute_pipeline_input_type(
                     let output_types: Vec<Type> = io_types
                         .into_iter()
                         .filter(|(in_type, _)| {
-                            current_type == Type::Any || in_type == &Type::Any || in_type == &current_type
+                            current_type == Type::Any
+                                || in_type == &Type::Any
+                                || in_type == &current_type
                         })
                         .map(|(_, out_type)| out_type)
                         .collect();
 
-                    current_type = match output_types.len() {
-                        0 => Type::Any,
-                        1 => output_types.into_iter().next().unwrap(),
-                        _ => Type::Any, // multiple possibilities, can't narrow
+                    current_type = if output_types.len() == 1 {
+                        output_types.into_iter().next().unwrap_or(Type::Any)
+                    } else {
+                        Type::Any // 0 or multiple possibilities, can't narrow
                     };
                 }
             } else {
@@ -325,8 +325,7 @@ impl NuCompleter {
         let Some(text) = contents.get(start_offset..pos) else {
             return vec![];
         };
-        let pipeline_input_type =
-            compute_pipeline_input_type(&block, working_set, pos_to_search);
+        let pipeline_input_type = compute_pipeline_input_type(&block, working_set, pos_to_search);
 
         self.complete_by_expression(
             working_set,
@@ -347,6 +346,7 @@ impl NuCompleter {
     /// * `pos` - cursor position, should be > offset
     /// * `prefix_str` - all the text before the cursor, within the `element_expression`
     /// * `strip` - whether to strip the extra placeholder from a span
+    #[allow(clippy::too_many_arguments)]
     fn complete_by_expression(
         &self,
         working_set: &StateWorkingSet,

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -208,6 +208,36 @@ fn misc_command_argument_completions(
     match_suggestions(&expected, &suggestions);
 }
 
+// Tests for pipeline-aware column name completion (e.g. `ls | sort-by <TAB>`)
+// Suggestions come back sorted alphabetically by the matcher.
+#[rstest]
+#[case::ls_sort_by("ls | sort-by ", None, vec!["modified", "name", "size", "type"])]
+#[case::ls_sort_by_prefix("ls | sort-by m", None, vec!["modified"])]
+#[case::ls_select("ls | select ", None, vec!["modified", "name", "size", "type"])]
+fn pipeline_column_completions(
+    #[case] input: &str,
+    #[case] pos: Option<usize>,
+    #[case] expected: Vec<&str>,
+) {
+    let (_, _, engine, stack) = new_engine();
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let suggestions = completer.complete(input, pos.unwrap_or(input.len()));
+    match_suggestions(&expected, &suggestions);
+}
+
+#[cfg(unix)]
+#[test]
+fn pipeline_column_completions_ls_long_unix() {
+    let (_, _, engine, stack) = new_engine();
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let suggestions = completer.complete("ls -l | sort-by ", 16);
+    let expected = vec![
+        "accessed", "created", "group", "inode", "mode", "modified", "name", "num_links",
+        "readonly", "size", "target", "type", "user",
+    ];
+    match_suggestions(&expected, &suggestions);
+}
+
 #[rstest]
 #[case::command_name("my-c", None, vec!["my-command"])]
 #[case::command_argument("my-command ", None, vec!["cat", "dog", "eel"])]

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -214,6 +214,8 @@ fn misc_command_argument_completions(
 #[case::ls_sort_by("ls | sort-by ", None, vec!["modified", "name", "size", "type"])]
 #[case::ls_sort_by_prefix("ls | sort-by m", None, vec!["modified"])]
 #[case::ls_select("ls | select ", None, vec!["modified", "name", "size", "type"])]
+#[case::which_sort_by("which cargo | sort-by ", None, vec!["command", "path", "type"])]
+#[case::sys_disks("sys disks | sort-by ", None, vec!["device", "free", "kind", "mount", "removable", "total", "type"])]
 fn pipeline_column_completions(
     #[case] input: &str,
     #[case] pos: Option<usize>,
@@ -225,6 +227,16 @@ fn pipeline_column_completions(
     match_suggestions(&expected, &suggestions);
 }
 
+#[cfg(not(windows))]
+#[test]
+fn pipeline_column_completions_ps_unix() {
+    let (_, _, engine, stack) = new_engine();
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let suggestions = completer.complete("ps | select ", 12);
+    let expected = vec!["cpu", "mem", "name", "pid", "ppid", "status", "virtual"];
+    match_suggestions(&expected, &suggestions);
+}
+
 #[cfg(unix)]
 #[test]
 fn pipeline_column_completions_ls_long_unix() {
@@ -232,8 +244,19 @@ fn pipeline_column_completions_ls_long_unix() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let suggestions = completer.complete("ls -l | sort-by ", 16);
     let expected = vec![
-        "accessed", "created", "group", "inode", "mode", "modified", "name", "num_links",
-        "readonly", "size", "target", "type", "user",
+        "accessed",
+        "created",
+        "group",
+        "inode",
+        "mode",
+        "modified",
+        "name",
+        "num_links",
+        "readonly",
+        "size",
+        "target",
+        "type",
+        "user",
     ];
     match_suggestions(&expected, &suggestions);
 }

--- a/crates/nu-command/src/filesystem/du.rs
+++ b/crates/nu-command/src/filesystem/du.rs
@@ -178,6 +178,25 @@ impl Command for Du {
             result: None,
         }]
     }
+
+    fn infer_output_type(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &nu_protocol::ast::Call,
+        _input_type: &Type,
+    ) -> Option<Type> {
+        let long = call.has_flag_const(working_set, "long").unwrap_or(false);
+        let mut columns: Vec<(String, Type)> = vec![
+            ("path".into(), Type::String),
+            ("apparent".into(), Type::Filesize),
+            ("physical".into(), Type::Filesize),
+        ];
+        if long {
+            columns.push(("directories".into(), Type::Any));
+            columns.push(("files".into(), Type::Any));
+        }
+        Some(Type::Table(columns.into()))
+    }
 }
 
 fn du_for_one_pattern(

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -188,6 +188,45 @@ impl Command for Ls {
             .category(Category::FileSystem)
     }
 
+    fn infer_output_type(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &nu_protocol::ast::Call,
+        _input_type: &Type,
+    ) -> Option<Type> {
+        let long = call.has_flag_const(working_set, "long").unwrap_or(false);
+
+        let mut columns: Vec<(String, Type)> = vec![
+            ("name".into(), Type::String),
+            ("type".into(), Type::String),
+        ];
+
+        if long {
+            columns.push(("target".into(), Type::String));
+            columns.push(("readonly".into(), Type::Bool));
+
+            #[cfg(unix)]
+            {
+                columns.push(("mode".into(), Type::String));
+                columns.push(("num_links".into(), Type::Int));
+                columns.push(("inode".into(), Type::Int));
+                columns.push(("user".into(), Type::String));
+                columns.push(("group".into(), Type::String));
+            }
+        }
+
+        columns.push(("size".into(), Type::Filesize));
+
+        if long {
+            columns.push(("created".into(), Type::Date));
+            columns.push(("accessed".into(), Type::Date));
+        }
+
+        columns.push(("modified".into(), Type::Date));
+
+        Some(Type::list(Type::Record(columns.into())))
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -196,10 +196,8 @@ impl Command for Ls {
     ) -> Option<Type> {
         let long = call.has_flag_const(working_set, "long").unwrap_or(false);
 
-        let mut columns: Vec<(String, Type)> = vec![
-            ("name".into(), Type::String),
-            ("type".into(), Type::String),
-        ];
+        let mut columns: Vec<(String, Type)> =
+            vec![("name".into(), Type::String), ("type".into(), Type::String)];
 
         if long {
             columns.push(("target".into(), Type::String));

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -53,6 +53,56 @@ impl Command for Ps {
         run_ps(engine_state, stack, call)
     }
 
+    fn infer_output_type(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &nu_protocol::ast::Call,
+        _input_type: &Type,
+    ) -> Option<Type> {
+        let long = call.has_flag_const(working_set, "long").unwrap_or(false);
+        let mut columns: Vec<(String, Type)> = vec![
+            ("pid".into(), Type::Int),
+            ("ppid".into(), Type::Int),
+            ("name".into(), Type::String),
+        ];
+        #[cfg(not(windows))]
+        columns.push(("status".into(), Type::String));
+        columns.push(("cpu".into(), Type::Float));
+        columns.push(("mem".into(), Type::Filesize));
+        columns.push(("virtual".into(), Type::Filesize));
+        if long {
+            columns.push(("command".into(), Type::String));
+            #[cfg(target_os = "linux")]
+            {
+                columns.push(("start_time".into(), Type::Date));
+                columns.push(("user_id".into(), Type::Int));
+                columns.push(("process_group_id".into(), Type::Int));
+                columns.push(("session_id".into(), Type::Int));
+                columns.push(("priority".into(), Type::Int));
+                columns.push(("process_threads".into(), Type::Int));
+                columns.push(("cwd".into(), Type::String));
+            }
+            #[cfg(windows)]
+            {
+                columns.push(("start_time".into(), Type::Date));
+                columns.push(("user".into(), Type::String));
+                columns.push(("user_sid".into(), Type::String));
+                columns.push(("priority".into(), Type::Int));
+                columns.push(("cwd".into(), Type::String));
+                columns.push(("environment".into(), Type::list(Type::String)));
+            }
+            #[cfg(target_os = "macos")]
+            {
+                columns.push(("start_time".into(), Type::Date));
+                columns.push(("user_id".into(), Type::Int));
+                columns.push(("priority".into(), Type::Int));
+                columns.push(("process_threads".into(), Type::Int));
+                columns.push(("cwd".into(), Type::String));
+            }
+        }
+        Some(Type::Table(columns.into()))
+    }
+
     fn examples(&self) -> Vec<Example<'_>> {
         vec![
             Example {

--- a/crates/nu-command/src/system/sys/cpu.rs
+++ b/crates/nu-command/src/system/sys/cpu.rs
@@ -44,6 +44,26 @@ impl Command for SysCpu {
             result: None,
         }]
     }
+
+    fn infer_output_type(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &nu_protocol::ast::Call,
+        _input_type: &Type,
+    ) -> Option<Type> {
+        let long = call.has_flag_const(working_set, "long").unwrap_or(false);
+        let mut columns: Vec<(String, Type)> = vec![
+            ("name".into(), Type::String),
+            ("brand".into(), Type::String),
+            ("vendor_id".into(), Type::String),
+            ("freq".into(), Type::Int),
+            ("load_average".into(), Type::String),
+        ];
+        if long {
+            columns.push(("cpu_usage".into(), Type::Float));
+        }
+        Some(Type::Table(columns.into()))
+    }
 }
 
 fn cpu(long: bool, span: Span) -> Value {

--- a/crates/nu-command/src/system/sys/disks.rs
+++ b/crates/nu-command/src/system/sys/disks.rs
@@ -14,7 +14,21 @@ impl Command for SysDisks {
         Signature::build("sys disks")
             .filter()
             .category(Category::System)
-            .input_output_types(vec![(Type::Nothing, Type::table())])
+            .input_output_types(vec![(
+                Type::Nothing,
+                Type::Table(
+                    [
+                        ("device".into(), Type::String),
+                        ("type".into(), Type::String),
+                        ("mount".into(), Type::String),
+                        ("total".into(), Type::Filesize),
+                        ("free".into(), Type::Filesize),
+                        ("removable".into(), Type::Bool),
+                        ("kind".into(), Type::String),
+                    ]
+                    .into(),
+                ),
+            )])
     }
 
     fn description(&self) -> &str {

--- a/crates/nu-command/src/system/sys/net.rs
+++ b/crates/nu-command/src/system/sys/net.rs
@@ -14,7 +14,19 @@ impl Command for SysNet {
         Signature::build("sys net")
             .filter()
             .category(Category::System)
-            .input_output_types(vec![(Type::Nothing, Type::table())])
+            .input_output_types(vec![(
+                Type::Nothing,
+                Type::Table(
+                    [
+                        ("name".into(), Type::String),
+                        ("mac".into(), Type::String),
+                        ("ip".into(), Type::list(Type::Any)),
+                        ("sent".into(), Type::Filesize),
+                        ("recv".into(), Type::Filesize),
+                    ]
+                    .into(),
+                ),
+            )])
     }
 
     fn description(&self) -> &str {

--- a/crates/nu-command/src/system/sys/temp.rs
+++ b/crates/nu-command/src/system/sys/temp.rs
@@ -13,7 +13,17 @@ impl Command for SysTemp {
         Signature::build("sys temp")
             .filter()
             .category(Category::System)
-            .input_output_types(vec![(Type::Nothing, Type::table())])
+            .input_output_types(vec![(
+                Type::Nothing,
+                Type::Table(
+                    [
+                        ("unit".into(), Type::String),
+                        ("temp".into(), Type::Float),
+                        ("high".into(), Type::Float),
+                    ]
+                    .into(),
+                ),
+            )])
     }
 
     fn description(&self) -> &str {

--- a/crates/nu-command/src/system/sys/users.rs
+++ b/crates/nu-command/src/system/sys/users.rs
@@ -13,7 +13,17 @@ impl Command for SysUsers {
     fn signature(&self) -> Signature {
         Signature::build("sys users")
             .category(Category::System)
-            .input_output_types(vec![(Type::Nothing, Type::table())])
+            .input_output_types(vec![(
+                Type::Nothing,
+                Type::Table(
+                    [
+                        ("id".into(), Type::Any),
+                        ("name".into(), Type::String),
+                        ("groups".into(), Type::list(Type::String)),
+                    ]
+                    .into(),
+                ),
+            )])
     }
 
     fn description(&self) -> &str {

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -16,7 +16,17 @@ impl Command for Which {
 
     fn signature(&self) -> Signature {
         Signature::build("which")
-            .input_output_types(vec![(Type::Nothing, Type::table())])
+            .input_output_types(vec![(
+                Type::Nothing,
+                Type::Table(
+                    [
+                        ("command".into(), Type::String),
+                        ("path".into(), Type::String),
+                        ("type".into(), Type::String),
+                    ]
+                    .into(),
+                ),
+            )])
             .allow_variants_without_examples(true)
             .rest("applications", SyntaxShape::String, "Application(s).")
             .switch("all", "List all executables.", Some('a'))

--- a/crates/nu-protocol/src/engine/command.rs
+++ b/crates/nu-protocol/src/engine/command.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use super::{EngineState, Stack, StateWorkingSet};
 use crate::{
     Alias, BlockId, DeprecationEntry, DynamicCompletionCallRef, DynamicSuggestion, Example,
-    OutDest, PipelineData, ShellError, Signature, Span, Value, engine::Call,
+    OutDest, PipelineData, ShellError, Signature, Span, Type, Value, engine::Call,
 };
 use std::{borrow::Cow, fmt::Display};
 
@@ -167,6 +167,24 @@ pub trait Command: Send + Sync + CommandClone {
 
     fn pipe_redirection(&self) -> (Option<OutDest>, Option<OutDest>) {
         (None, None)
+    }
+
+    /// Infer the output type of this command given a specific call.
+    ///
+    /// This allows commands whose output columns depend on flags (e.g. `ls --long`)
+    /// to provide more accurate type information at parse time. Used by the
+    /// completion system to suggest column names in pipelines.
+    ///
+    /// Returns `None` by default, which falls back to the static `input_output_types`
+    /// from the command's signature.
+    #[allow(unused_variables)]
+    fn infer_output_type(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &crate::ast::Call,
+        input_type: &Type,
+    ) -> Option<Type> {
+        None
     }
 
     // engine_state and stack are required to get completion from plugin.


### PR DESCRIPTION
Tab-completion in pipelines is missing a really nice quality-of-life thing today: when I'm building up `ls | sort-by ` and hit tab, nushell has no idea that `ls` produces records with `name`, `type`, `size`, `modified` columns, so I get nothing useful. This PR is a first stab at fixing that.

After this PR:

- `ls | sort-by <TAB>` suggests `modified`, `name`, `size`, `type`
- `ls | sort-by m<TAB>` narrows to `modified`
- `ls | select <TAB>` works the same way (different command, same `CellPath` arg shape)
- `ls -l | sort-by <TAB>` is **flag-aware** and adds `target`, `readonly`, `mode`, `num_links`, `inode`, `user`, `group`, `created`, `accessed` — all the extra columns that `--long` produces
- `ps | sort-by <TAB>` suggests `pid`, `ppid`, `name`, `status`, `cpu`, `mem`, `virtual`, and `ps -l` adds all the `--long` columns too
- `which cargo | sort-by <TAB>`, `sys disks | sort-by <TAB>`, `sys cpu | sort-by <TAB>`, `du | sort-by <TAB>`, etc. all work

It's best-effort and only as good as the type info each command exposes, but I think that's a fine starting point.

## How it works

Two pieces had to come together:

1. **The completer was pipeline-blind.** `find_pipeline_element_by_position()` finds the expression at the cursor but throws away the pipeline context, so when completing `sort-by`'s argument it has no way to ask "what does the left side of this pipe produce?". I added a `compute_pipeline_input_type()` helper that walks the elements preceding the cursor and propagates types forward.

2. **`ls` (and most other commands) didn't declare their output columns.** Only ~15 commands across the whole codebase use `Type::Record(...)` or `Type::Table(...)` with field names today — the rest just use `Type::table()`. So even with perfect plumbing, `ls | sort-by <TAB>` would produce nothing because `ls` declared its output as a generic table.

For commands like `ls` whose output depends on flags (`--long`, `--mime-type`), declaring static `input_output_types` doesn't really work. So I added a new optional method on the `Command` trait:

```rust
fn infer_output_type(
    &self,
    working_set: &StateWorkingSet,
    call: &ast::Call,
    input_type: &Type,
) -> Option<Type>
```

This is called at *parse time* during completion, so it can use `Call::has_flag_const()` to peek at flags without running anything. `Ls::infer_output_type()` checks `--long` and returns the appropriate `Table` type with all the right columns. The completer prefers this over the static signature when available.

When the cell-path argument is being completed, `ArgValueCompletion` checks if the positional's `SyntaxShape` includes `CellPath` (directly or inside a `OneOf`) and if so, extracts column names from the inferred input type using the existing `get_suggestions_by_type()` helper from `cell_path_completions.rs`.

## Details

1. Added `Command::infer_output_type()` with a default `None` impl in `nu-protocol`
2. Added `compute_pipeline_input_type()` in `nu-cli/src/completions/completer.rs` — walks preceding pipeline elements, calls `infer_output_type()` when available, falls back to the signature's `input_output_types`
3. Threaded the inferred type through `complete_by_expression()` into a new `pipeline_input_type` field on `ArgValueCompletion`
4. In `ArgValueCompletion::fetch()`, if the positional accepts `CellPath` and we have an input type with column info, return column suggestions
5. Made `get_suggestions_by_type()` `pub(crate)` so it can be reused (it already does exactly the type→columns extraction we need, including `Type::List(Record)` and `Type::OneOf`)

### Commands enriched in this PR

- **Flag-aware via `infer_output_type()`:** `ls`, `ps`, `sys cpu`, `du`, `history` (assumes the sqlite backend, which is the default)
- **Static `input_output_types` with named columns:** `which`, `sys disks`, `sys net`, `sys users`, `sys temp`

## Future work

The mechanical follow-up is enriching the rest of the table-producing commands. Anything that gets a typed `Type::Record`/`Type::Table` in its signature, or implements `infer_output_type()`, will work with this completion machinery for free.

Things this PR deliberately doesn't try to do:

- **Runtime evaluation of the LHS.** For things like `open foo.csv | sort-by <TAB>` where the columns are only knowable at runtime, the completer could actually evaluate `open foo.csv` and inspect the resulting value (similar to what `CellPathCompletion` does for `$var.field<TAB>`). I left this out because it raises perf and side-effect concerns and I wanted to keep the PR focused.
- **Multiple `input_output_types` variants based on flags.** `infer_output_type()` is more flexible anyway.

## Testing

Added unit tests in `crates/nu-cli/tests/completions/mod.rs` that drive `NuCompleter::complete()` with real input strings:

```rust
#[case::ls_sort_by("ls | sort-by ", ..., vec!["modified", "name", "size", "type"])]
#[case::ls_sort_by_prefix("ls | sort-by m", ..., vec!["modified"])]
#[case::ls_select("ls | select ", ..., vec!["modified", "name", "size", "type"])]
#[case::which_sort_by("which cargo | sort-by ", ..., vec!["command", "path", "type"])]
#[case::sys_disks("sys disks | sort-by ", ..., vec!["device", "free", "kind", "mount", "removable", "total", "type"])]
fn pipeline_column_completions(...) { ... }

#[cfg(unix)]
fn pipeline_column_completions_ls_long_unix() {
    // ls -l | sort-by  → adds target, readonly, mode, num_links, inode, user, group, created, accessed
}

#[cfg(not(windows))]
fn pipeline_column_completions_ps_unix() {
    // ps | select  → cpu, mem, name, pid, ppid, status, virtual
}
```

All pass. I also ran the full `nu-cli` completions suite — only the pre-existing `variables_completions` failure showed up, which I confirmed by running `git stash && cargo test` on clean `main` (it fails there too, unrelated to this PR). `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` are also clean.

I did **not** open `nu` interactively and hit tab. The unit tests exercise the same `NuCompleter::complete(line, pos)` API that reedline calls on tab, so they're a faithful test, but they don't catch things like menu rendering. Worth a manual smoke test before merging IMO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)